### PR TITLE
Rewrite Leuven post around founding Airflora there

### DIFF
--- a/content/posts/2026-05-22-leuven.mdx
+++ b/content/posts/2026-05-22-leuven.mdx
@@ -1,11 +1,28 @@
 ---
-title: Home base, for now
+title: Why I'm building here
 date: 2026-05-22
 type: place
 location: Leuven, Belgium
-tags: [thoughts]
+tags: [thoughts, building]
 ---
 
 A university town that empties and fills with the semesters, rain that can't
-make up its mind, and the best quiet cafés in Belgium to think in. Leuven has
-been good to me.
+make up its mind, and the best quiet cafés in Belgium to think in.
+
+It's also where I decided to set up [Airflora](https://airflora.care), and that
+part wasn't sentiment.
+
+Talent first. For a city this size the density of international people is almost
+unreasonable — KU Leuven pulls researchers in from everywhere, and enough of them
+stay that you can hire for something narrow and actually find the person. The
+university is the engine behind that, not just a name on a ranking.
+
+Then the ecosystem that grew up around it, which genuinely wants you to try:
+Start it @KBC on the accelerator side, imec when the work needs more than a
+laptop, and KICK for the student and spin-off energy coming out of KU Leuven.
+None of it guarantees anything. It removes the friction that makes starting
+something somewhere else lonely.
+
+The rest is just the city — small enough to cross on foot, half an hour from a
+major airport, quiet enough to think in. Home base, and now something more
+settled than that.


### PR DESCRIPTION
Reframes `content/posts/2026-05-22-leuven.mdx` from a short impression of the town into the reasons for setting the company up there.

## What changed

- **Body** — the decision to set up [Airflora](https://airflora.care) in Leuven, then the reasons: international talent density, KU Leuven as the engine behind it, the surrounding ecosystem (Start it @KBC, imec, KICK), and the city itself as the closer. The original opening line about the semesters and the cafés is kept as the scene.
- **Title** — "Home base, for now" → "Why I'm building here". The closing line now turns the old title over on purpose, since founding a company somewhere is the opposite of "for now".
- **Tags** — `[thoughts]` → `[thoughts, building]`. Date, `type: place`, and `location` unchanged, so the slug and post ordering stay put.

## Worth a check before merging

Three details came from dictation and I may have misheard them:

- **KICK** — the KU Leuven student-entrepreneurship community. This is the name I'm least sure of; worth confirming the exact spelling.
- **Airflora** — read as the intended company, matching `config/content.ts:121` and the site bio.
- **Start it @KBC** — KBC's branding for the accelerator; "the KBC accelerator" works too.

Each is a one-line fix.

## Verification

Content-only change; no build was run in this session (the container has no `node_modules`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ji7Y2WyHsGcP1G9t2RZCQ)_