### PR TITLE
Rewrite song post around late-night Chet Baker

### DIFF
--- a/content/posts/2026-06-10-on-repeat.mdx
+++ b/content/posts/2026-06-10-on-repeat.mdx
@@ -1,10 +1,16 @@
 ---
-title: On repeat this month
+title: Late nights, Chet Baker
 date: 2026-06-10
 type: song
-url: https://open.spotify.com/track/2CAirvB4PRUmE83C7tppde
+url: https://open.spotify.com/track/2FOR3eTvl2zGwA3OHbKUeg
 tags: [music]
 ---
 
-The one I keep coming back to when the code won't compile and neither will I.
-Turn it up.
+Chet Baker for the late hours — a trumpet that sounds like it's turning
+something over rather than announcing it, and a voice that barely bothers to
+project.
+
+This goes on when the day is finished and I'm not. Lights low, a window open,
+the hour that's better for reflecting than for deciding. Moonlight music.
+
+Keep it low.

--- a/content/posts/2026-06-10-on-repeat.mdx
+++ b/content/posts/2026-06-10-on-repeat.mdx
@@ -10,7 +10,7 @@ Chet Baker for the late hours — a trumpet that sounds like it's turning
 something over rather than announcing it, and a voice that barely bothers to
 project.
 
-This goes on when the day is finished and I'm not. Lights low, a window open,
+This goes on when the day is finished and I'm not. Lights low on the terrace,
 the hour that's better for reflecting than for deciding. Moonlight music.
 
 Keep it low.


### PR DESCRIPTION
Swaps the track in `content/posts/2026-06-10-on-repeat.mdx` and rewrites the note around the late-night mood it belongs to.

## What changed

- **Track** — now the Chet Baker one. Stored without the `si` and `utm_source` params that Spotify's copy-link appends; `trackId()` in `components/SpotifyTrack.tsx:4` parses either form, so the embed is unaffected.
- **Title** — "On repeat this month" → "Late nights, Chet Baker".
- **Body** — the trumpet and voice, then the scene: lights low on the terrace, the hour better for reflecting than deciding.
- **Closing line** — "Turn it up" → "Keep it low", which suits this music.

Date, `type: song`, and tags are unchanged, so the slug and post ordering stay put.

## Note

The post names the artist but not the song. Spotify's oEmbed endpoint and track pages both return 403 from the session container, so the title could not be verified from here, and guessing it in the prose seemed worse than leaving it out. The rendered page is unaffected: `SpotifyTrack` embeds Spotify's official player, which shows the real title and album art.

## Verification

Content-only change; no build was run in this session (the container has no `node_modules`).

---

_Correction: an earlier edit to this description claimed it also covered the Garagum post. It does not — this PR merged before that work was pushed. The Garagum change is in a separate pull request._