### PR TITLE
Expand Garagum post with the story behind the planting

### DIFF
--- a/content/posts/2026-06-28-restor-garagum.mdx
+++ b/content/posts/2026-06-28-restor-garagum.mdx
@@ -3,9 +3,27 @@ title: Watching the desert come back
 date: 2026-06-28
 type: link
 url: https://restor.eco/sites/884aa71c-21d7-4dbf-9222-8f6c41fd1b71
-tags: [nature]
+tags: [nature, family]
 ---
 
-An effort close to home: bringing a stretch of the Garagum desert back to life —
-my family's patch of it. You can follow the site on Restor — satellite imagery,
-species, the slow green returning frame by frame.
+Five hectares beside the Garagum canal, where we started planting in 2022.
+
+Around two thousand trees now, most of them fruit — apricot, peach, plum, apple,
+cherry, berries, all local varieties — plus others put in purely for shade and
+for the birds. My father runs it: the irrigation, the pruning, and the yearly
+accounting of what made it through. Whatever didn't gets replaced, so the land
+stays fully planted instead of quietly thinning out.
+
+It's working. There are more animals than there were, more birds, more of
+everything that turns up once there's water and cover.
+
+But the trees are half the point. My nephews and cousins come out through the
+year, in every season, and what they're picking up there isn't gardening — it's
+that you can be part of an ecosystem rather than its ruler. That's what I want
+the place to teach, and it teaches better standing in it than said out loud.
+
+For the older ones it's simpler. Somewhere to put the week down and do something
+slow, together, with the people they love.
+
+You can follow the site on Restor — satellite imagery, species, the slow green
+returning frame by frame.


### PR DESCRIPTION
Expands `content/posts/2026-06-28-restor-garagum.mdx` from a short link note into the story behind the site it links to.

## What changed

- Five hectares beside the Garagum canal, planted from 2022, around two thousand trees.
- Mostly local fruit varieties — apricot, peach, plum, apple, cherry, berries — plus trees put in for shade and for the birds.
- Kept up by my father: the irrigation, the pruning, and replacing what didn't survive so the land stays fully planted.
- The wildlife that has returned, what the younger family members take from the place, and what it offers the older ones.
- The Restor link stays as the closing line.

**Tags** — `[nature]` → `[nature, family]`. This introduces a new filter chip in the posts browser with one post behind it. Title, date, `type: link`, and URL are unchanged, so the slug and post ordering stay put.

## Verification

Content-only change; no build was run in this session (the container has no `node_modules`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ji7Y2WyHsGcP1G9t2RZCQ)_