### PR TITLE
Rewrite Airflora milestone post around the May PMF milestone

### DIFF
--- a/content/posts/2026-07-15-clean-air-milestone.mdx
+++ b/content/posts/2026-07-15-clean-air-milestone.mdx
@@ -5,19 +5,18 @@ type: note
 tags: [building, thoughts]
 ---
 
-In May we cleared the first real hurdle — market validation, product-market fit,
-and the proof that we can build the thing and actually deliver it. Clean air
-stopped being a thesis and became a product people want.
+In May we cleared the first real hurdle: market validation, product-market fit,
+and proof that we can build this and deliver it. Daycares want it and we can
+ship it. That question is closed.
 
-No launch, no confetti. It's the least visible milestone a company gets, and the
-only one that decides whether there is a company at all.
+No launch, no confetti, nobody outside the company noticed. It's also the only
+milestone that decides whether there is a company at all.
 
-What it earns us is the next problem: distribution. More daycares, more children
-breathing better in the rooms where they spend their days. The goal for the next
-twelve months is to make that repeatable — to get the flywheel turning, so each
-year comes easier than the one before it instead of harder.
+What it earns us is the next problem: distribution, repeatable and growing. More
+daycares, more children covered. The twelve-month goal is to get the flywheel
+turning, so each year comes easier than the one before it instead of harder.
 
 I traded the piano for this kind of keyboard for exactly this. Children spend
 most of their waking hours indoors, in air nobody measures. We measure it and we
-fix it. Most rooms still don't have that — which is the opportunity, and the
-next few years of work.
+fix it. Most rooms still don't have that, and closing that gap is the next few
+years of work.

--- a/content/posts/2026-07-15-clean-air-milestone.mdx
+++ b/content/posts/2026-07-15-clean-air-milestone.mdx
@@ -17,6 +17,7 @@ breathing better in the rooms where they spend their days. The goal for the next
 twelve months is to make that repeatable — to get the flywheel turning, so each
 year comes easier than the one before it instead of harder.
 
-Still the reason I traded the piano for the other kind of keyboard: so a window
-gets opened on the right night, and a room full of small kids breathes easier
-for it.
+I traded the piano for this kind of keyboard for exactly this. Children spend
+most of their waking hours indoors, in air nobody measures. We measure it and we
+fix it. Most rooms still don't have that — which is the opportunity, and the
+next few years of work.

--- a/content/posts/2026-07-15-clean-air-milestone.mdx
+++ b/content/posts/2026-07-15-clean-air-milestone.mdx
@@ -5,8 +5,18 @@ type: note
 tags: [building, thoughts]
 ---
 
-Something clicked at work this week: enough clean-air data flowing that the
-model can flag a bad-air evening **before** it arrives, not after.
+In May we cleared the first real hurdle — market validation, product-market fit,
+and the proof that we can build the thing and actually deliver it. Clean air
+stopped being a thesis and became a product people want.
 
-No launch, no confetti. But this is the reason I traded the piano for the other
-kind of keyboard — so someone can open the window on the right night.
+No launch, no confetti. It's the least visible milestone a company gets, and the
+only one that decides whether there is a company at all.
+
+What it earns us is the next problem: distribution. More daycares, more children
+breathing better in the rooms where they spend their days. The goal for the next
+twelve months is to make that repeatable — to get the flywheel turning, so each
+year comes easier than the one before it instead of harder.
+
+Still the reason I traded the piano for the other kind of keyboard: so a window
+gets opened on the right night, and a room full of small kids breathes easier
+for it.


### PR DESCRIPTION
Rewrites `content/posts/2026-07-15-clean-air-milestone.mdx` around the milestone that actually happened, and in a plainer register.

## What changed

- **The milestone** — market validation, product-market fit, and proof we can build and deliver, cleared in May. The old post described a model capability ("can flag a bad-air evening before it arrives"), which was a product detail rather than the milestone.
- **Who it's for** — daycares and the children in them. The post never said this, and neither did anything else on the site.
- **What's next** — repeatable, growing distribution, with a twelve-month goal of getting the flywheel turning.
- **Register** — direct throughout rather than lyrical. The old closing image ("a window gets opened on the right night") stopped meaning anything once the subject became daycares; it now ends on the gap still to close. The piano detail is kept, stated flatly.

Title, date, `type: note`, and tags are unchanged, so the slug and post ordering stay put.

## Note

"Something clicked at work this week" was removed: the milestone was May and this post is dated 15 July, so it now reads as a reflection written after the fact rather than same-week news. Moving the date to May would fix the tense differently but would change the slug and the post ordering, so it was left alone.

No figures were added — daycares served, children covered, or similar. Concrete numbers would strengthen the opening paragraph, but none were available to verify.

## Verification

Content-only change; no build was run in this session (the container has no `node_modules`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ji7Y2WyHsGcP1G9t2RZCQ)_