### PR TITLE
Correct the ecosystem names in the Leuven post

### DIFF
--- a/content/posts/2026-05-22-leuven.mdx
+++ b/content/posts/2026-05-22-leuven.mdx
@@ -18,10 +18,12 @@ stay that you can hire for something narrow and actually find the person. The
 university is the engine behind that, not just a name on a ranking.
 
 Then the ecosystem that grew up around it, which genuinely wants you to try:
-Start it @KBC on the accelerator side, imec when the work needs more than a
-laptop, and KICK for the student and spin-off energy coming out of KU Leuven.
-None of it guarantees anything. It removes the friction that makes starting
-something somewhere else lonely.
+[Start it @KBC](https://www.startit.be) on the accelerator side,
+[imec](https://www.imec-int.com) when the work needs more than a laptop, and
+[KU Leuven KICK](https://lrd.kuleuven.be/kuleuvenkick/english) — with KICK House
+on Naamsestraat — for the student and spin-off energy coming out of the
+university. None of it guarantees anything. It removes the friction that makes
+starting something somewhere else lonely.
 
 The rest is just the city — small enough to cross on foot, half an hour from a
 major airport, quiet enough to think in. Home base, and now something more


### PR DESCRIPTION
Fixes an unverified name in `content/posts/2026-05-22-leuven.mdx` and links the three organisations it mentions.

## What changed

- **"KICK" → "KU Leuven KICK"**, with a mention of **KICK House on Naamsestraat**. The short form was my own shortening of a name I had not checked; the organisation runs under KU Leuven Research & Development, and KICK House is its hub.
- **Links added** for Start it @KBC, imec, and KU Leuven KICK, so a reader who doesn't already know them can follow along.
- The trailing "coming out of KU Leuven" became "coming out of the university", since the name now appears in the link text.

No other prose changed. Frontmatter is untouched.

## Verification

Names checked against the organisations' own pages:

- https://lrd.kuleuven.be/kuleuvenkick/english
- https://lrd.kuleuven.be/kuleuvenkick/english/about
- https://lrd.kuleuven.be/kuleuvenkick/english/kick-house-coming-soon

Content-only change; no build was run in this session (the container has no `node_modules`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ji7Y2WyHsGcP1G9t2RZCQ)_