### PR TITLE
Clamp long post bodies in list cards, expandable in place

### DIFF
--- a/components/ExpandableBody.tsx
+++ b/components/ExpandableBody.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { ChevronDownIcon } from "./icons";
+
+// Roughly six lines of the card's 15px/1.7 body type. List cards stay a
+// consistent height until you open one.
+const COLLAPSED_PX = 156;
+// Don't clamp a body that only just overflows — a "Read more" that reveals one
+// extra line is more annoying than the line itself.
+const SLACK_PX = 40;
+
+// Wraps a server-rendered post body in a list card and clamps it, with a fade
+// at the cut and a control that expands it in place. Height is animated from
+// the measured content height, then released to `none` once open so later
+// reflow (fonts, resize) can't clip anything.
+export default function ExpandableBody({ children }: { children: React.ReactNode }) {
+  const box = useRef<HTMLDivElement>(null);
+  const full = useRef(0);
+  const [measured, setMeasured] = useState(false);
+  const [expandable, setExpandable] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [settled, setSettled] = useState(false);
+  const id = useId();
+
+  useEffect(() => {
+    const el = box.current;
+    if (!el) return;
+
+    // scrollHeight reports the full content height even while max-height and
+    // overflow:hidden are clamping the box.
+    const measure = () => {
+      full.current = el.scrollHeight;
+      setExpandable(el.scrollHeight > COLLAPSED_PX + SLACK_PX);
+      setMeasured(true);
+    };
+    measure();
+
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const toggle = () => {
+    full.current = box.current?.scrollHeight ?? 0;
+    if (open) {
+      // Pin the height back to a pixel value before collapsing, since
+      // `none` -> a length doesn't animate.
+      setSettled(false);
+      requestAnimationFrame(() => setOpen(false));
+    } else {
+      setSettled(false);
+      setOpen(true);
+    }
+  };
+
+  // Clamp before the first measurement too, so a long body never flashes at
+  // full height on load. max-height (not height) means short bodies are
+  // unaffected either way.
+  const maxHeight = open
+    ? settled
+      ? "none"
+      : full.current
+    : !measured || expandable
+      ? COLLAPSED_PX
+      : undefined;
+
+  return (
+    <div className="mt-3">
+      <div
+        id={id}
+        ref={box}
+        className="relative overflow-hidden motion-safe:transition-[max-height] motion-safe:duration-500 motion-safe:ease-[cubic-bezier(0.16,1,0.3,1)]"
+        style={{ maxHeight }}
+        onTransitionEnd={(e) => {
+          if (e.propertyName === "max-height" && open) setSettled(true);
+        }}
+      >
+        {children}
+        {expandable && !open && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-b from-transparent to-[var(--surface)]"
+          />
+        )}
+      </div>
+
+      {expandable && (
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={open}
+          aria-controls={id}
+          className="mt-2.5 inline-flex items-center gap-1 text-xs font-medium text-soft transition-colors hover:text-accent"
+        >
+          {open ? "Show less" : "Read more"}
+          <ChevronDownIcon
+            className={`h-3.5 w-3.5 transition-transform duration-300 ${open ? "rotate-180" : ""}`}
+          />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import type { Post, PostType } from "@/lib/posts";
 import { formatPostDate } from "@/lib/posts";
+import ExpandableBody from "./ExpandableBody";
 import LinkPreviewCard from "./LinkPreviewCard";
 import SpotifyTrack from "./SpotifyTrack";
 import { ArrowIcon, MapPinIcon } from "./icons";
@@ -60,10 +61,18 @@ export default async function PostCard({
           </h3>
         ))}
 
-      {/* Body */}
-      <div className="prose-post mt-3 text-[15px]">
-        <MDXRemote source={post.content} />
-      </div>
+      {/* Body — clamped and expandable in list cards, always full standalone */}
+      {standalone ? (
+        <div className="prose-post mt-3 text-[15px]">
+          <MDXRemote source={post.content} />
+        </div>
+      ) : (
+        <ExpandableBody>
+          <div className="prose-post text-[15px]">
+            <MDXRemote source={post.content} />
+          </div>
+        </ExpandableBody>
+      )}
 
       {/* Type-specific enriched attachment */}
       {post.type === "link" && post.url && <LinkPreviewCard url={post.url} />}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -94,6 +94,14 @@ export function ArrowIcon(p: IconProps) {
   );
 }
 
+export function ChevronDownIcon(p: IconProps) {
+  return (
+    <svg {...base({ fill: "none", ...p })} stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
 export function ExternalIcon(p: IconProps) {
   return (
     <svg {...base({ fill: "none", ...p })} stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">


### PR DESCRIPTION
List cards rendered the full post body, so after the recent rewrites a long post made its card tower over the others. Cards now clamp the body and expand in place.

## What changed

- **New `components/ExpandableBody.tsx`** — a client wrapper around the server-rendered MDX body. Clamps to roughly six lines with a gradient fade at the cut, and a **Read more** / **Show less** control that animates the card open and closed.
- **`components/PostCard.tsx`** — list cards wrap the body in `ExpandableBody`; the standalone post page (`standalone`) is untouched and always shows the full text.
- **`components/icons.tsx`** — adds `ChevronDownIcon`, matching the existing icon style.

Applies to both list views: the home page recent posts and `/posts`.

## Implementation notes

- The clamp is a `max-height` present in the **server-rendered HTML**, so a long body never flashes at full height before hydration, and short bodies are unaffected by it.
- Height animates from the measured content height, then is released to `none` once open, so later reflow (font swap, resize) cannot clip the expanded text. Collapsing re-pins to a pixel value first, since `none` to a length does not animate.
- The control renders only when the body overflows by a meaningful margin, so a post that spills one extra line does not get a pointless "Read more".
- A `ResizeObserver` re-measures on reflow. Motion is behind `motion-safe:`, and the button carries `aria-expanded` / `aria-controls`.
- Type-specific attachments deliberately stay **outside** the collapse — the Spotify player, link preview, place badge, photo and video remain visible while collapsed, since they are the point of those cards.

## Verification

`pnpm build` and `tsc --noEmit` both pass. Behaviour checked in headless Chromium against the production build at `/posts`:

- 4 of 5 cards get a control; the short Chet Baker post correctly gets none.
- Collapsed bodies measure exactly 156px; re-collapsing returns to 156px.
- Expanding animates (335px mid-flight, 354px settled), the label flips to "Show less", and `aria-expanded` becomes `true`.
- Expanded text is not clipped, and the fade is absent when open.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ji7Y2WyHsGcP1G9t2RZCQ)_