### PR TITLE
Add post on the three things longevity protocols don't cover

### DIFF
--- a/content/posts/2026-08-08-making-room.mdx
+++ b/content/posts/2026-08-08-making-room.mdx
@@ -1,0 +1,30 @@
+---
+title: What I'm making room for
+date: 2026-08-08
+type: note
+tags: [thoughts, building]
+---
+
+Everyone is optimizing for longevity now. Biomarkers, protocols, supplements by
+the handful. I think they're right about prevention — most of what kills people
+can be seen coming, and measuring it is worth doing.
+
+But I don't think that's the whole of it. If you want a long life and a good one,
+I believe you need three things.
+
+Something from outside your own field. For me that's the piano. I gave it up to a
+life with no fixed address, and [Leuven](/posts/2026-05-22-leuven) is the first
+address I've had in years.
+
+Something physical that isn't training. Mine is a walk before the day starts,
+twenty minutes, to put my head back in order.
+
+And the people you love, close enough to see. Mine are scattered from Turkmenistan
+to Europe to the US, so that one I can't simply have. You have to build a
+reason for everyone to be in the same place. That's part of why we're planting
+[five hectares of desert](/posts/2026-06-28-restor-garagum).
+
+None of it arrives on its own. It takes a certain privilege — time, money, access,
+a culture with room for it — and that has to be built on purpose rather than waited
+for. The company is the main block I'm laying, and I want all three at full size,
+not in the margins of a week.


### PR DESCRIPTION
Adds `content/posts/2026-08-08-making-room.mdx`, a new note.

## The argument

Prevention and biomarkers are right as far as they go — most of what kills people can be seen coming. But a long and good life also needs three things no protocol covers:

- something from outside your own field (the piano, given up to a life with no fixed address)
- something physical that isn't training (a twenty-minute walk before the day starts)
- the people you love, close enough to see — the hard one, with family and friends scattered from Turkmenistan to the US to Southeast Asia

It closes on the company being the foundation being laid for all three, rather than an admission of neglect.

## Cross-links

Two inline links, since three posts now talk to each other:

- "Leuven" → `/posts/2026-05-22-leuven`
- "five hectares of desert" → `/posts/2026-06-28-restor-garagum`

Easy to drop if they read as too busy.

## Frontmatter

`type: note`, tagged `thoughts` and `building`. Dated 2026-08-08, so it sorts to the top of the list.

## Verification

`pnpm build` passes and the post prerenders at `/posts/2026-08-08-making-room`, with its OG image route generated alongside.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ji7Y2WyHsGcP1G9t2RZCQ)_